### PR TITLE
Wait for the pull to be completed before continuing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+upkick
+upkick.1

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -12,8 +12,9 @@ func TestEventString(t *testing.T) {
 		Value: "bar",
 	}
 	expected := "foo{volume=\"baz\",instance=\"qux\"} bar"
-	if e.String() != expected {
-		t.Fatalf("Expected %s, got %s", expected, e.String())
+	expected2 := "foo{instance=\"qux\", volume=\"baz\"} bar"
+	if e.String() != expected && e.String() != expected2 {
+		t.Fatalf("Expected <%s>, got <%s>", expected, e.String())
 	}
 }
 


### PR DESCRIPTION
Fix a bug where upkick has to run twice before the containers are
actually restarted